### PR TITLE
Fix when creating token constant from client post request

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -8,7 +8,7 @@ const SECRET_KEY = '1x0000000000000000000000000000000AA';
 async function handlePost(request) {
     const body = await request.formData();
     // Turnstile injects a token in "cf-turnstile-response".
-    const token = body['cf-turnstile-response'];
+    const token = body.get('cf-turnstile-response');
     const ip = request.headers.get('CF-Connecting-IP');
 
     // Validate the token by calling the "/siteverify" API.


### PR DESCRIPTION
Must use FormData.get() method when getting values from FormData object. Bracket notation will result in undefined.